### PR TITLE
Replaces "colorize" dependency with "pastel"

### DIFF
--- a/lib/sphinxtrain.rb
+++ b/lib/sphinxtrain.rb
@@ -1,5 +1,5 @@
 require "pocketsphinx-ruby"
-require "colorize"
+require "pastel"
 require "word_aligner"
 
 require "sphinxtrain/version"

--- a/lib/sphinxtrain/trainer.rb
+++ b/lib/sphinxtrain/trainer.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'pastel'
 
 module Sphinxtrain
   class Trainer
@@ -125,7 +126,7 @@ module Sphinxtrain
     end
 
     def log(message, color = :green)
-      puts message.colorize(color)
+      puts ::Pastel.new.method(color).call(message)
     end
   end
 end

--- a/sphinxtrain-ruby.gemspec
+++ b/sphinxtrain-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "pocketsphinx-ruby", "~> 0.3.0"
   spec.add_dependency "word_aligner", "~> 0.1.2"
-  spec.add_dependency "colorize", "~> 0.7.3"
+  spec.add_dependency "pastel", "~> 0.7.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rspec", "~> 3.1.0"


### PR DESCRIPTION
This change is motivated by license compatibility. colorize uses the
GPL-2.0 license, where pastel uses the MIT license (as
sphinxtrain-ruby does).